### PR TITLE
Add ini service provider loader

### DIFF
--- a/index.php
+++ b/index.php
@@ -14,17 +14,13 @@ use Joomla\Http\Middleware\ResponseSenderMiddleware;
 use Joomla\Http\Middleware\RouterMiddleware;
 use Joomla\Http\ServerRequestFactory;
 use Joomla\J3Compatibility\Http\Middleware\RouterMiddleware as LegacyRouterMiddleware;
+use Joomla\DI\Loader\IniLoader;
 
 require_once 'libraries/vendor/autoload.php';
 
 $root = __DIR__;
 $container = new \Joomla\DI\Container();
-
-$services = parse_ini_file($root . '/config/services.ini', true);
-foreach ($services['provider'] as $alias => $service)
-{
-	$container->registerServiceProvider(new $service, $alias);
-}
+(new IniLoader($container))->loadFromFile($root . '/config/services.ini');
 
 $app  = new Application(
 	[

--- a/libraries/incubator/DI/Loader/IniLoader.php
+++ b/libraries/incubator/DI/Loader/IniLoader.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Part of the Joomla Framework DI Package
+ *
+ * @copyright  Copyright (C) 2013 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+namespace Joomla\DI\Loader;
+use Joomla\DI\Container;
+
+/**
+ * Fills a container with service providers from an ini string.
+ * The key is the alias and the value the class which can be registered as
+ * service provider.
+ * The structure of the ini string must be:
+ *
+ * [provider]
+ * dispatcher = "\\MyApp\\Service\\MyServiceProvider"
+ */
+class IniLoader implements LoaderInterface
+{
+
+	private $container = null;
+
+	public function __construct (Container $container)
+	{
+		$this->container = $container;
+	}
+
+	/**
+	 * Helper function to load the services from a file.
+	 *
+	 * @param string $filename
+	 * @see LoaderInterface::load()
+	 */
+	public function loadFromFile ($filename)
+	{
+		$this->load(file_get_contents($filename));
+	}
+
+	public function load ($content)
+	{
+		$services = parse_ini_string($content, true);
+		if (! key_exists('provider', $services))
+		{
+			return;
+		}
+
+		foreach ($services['provider'] as $alias => $service)
+		{
+			if (! class_exists($service))
+			{
+				continue;
+			}
+			$this->container->registerServiceProvider(new $service(), $alias);
+		}
+	}
+}

--- a/libraries/incubator/DI/Loader/LoaderInterface.php
+++ b/libraries/incubator/DI/Loader/LoaderInterface.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Part of the Joomla Framework DI Package
+ *
+ * @copyright  Copyright (C) 2013 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+namespace Joomla\DI\Loader;
+
+/**
+ * Defines the interface for a service provider loader.
+ */
+interface LoaderInterface
+{
+
+	/**
+	 * Loads service providers from the content.
+	 *
+	 * @param string $content
+	 */
+	public function load ($content);
+}

--- a/tests/unit/DI/Loader/IniLoaderTest.php
+++ b/tests/unit/DI/Loader/IniLoaderTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2013 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+namespace Joomla\Tests\Unit\DI\Loader;
+use Joomla\DI\Container;
+use Joomla\DI\Loader\IniLoader;
+include_once __DIR__ . '/../Stubs/SimpleServiceProvider.php';
+
+/**
+ * Tests for Container class.
+ */
+class IniLoaderTest extends \PHPUnit_Framework_TestCase
+{
+
+	/**
+	 * @testdox Loading a string
+	 */
+	public function testLoadString ()
+	{
+		$content = <<<EOF
+[provider]
+foo = "\\SimpleServiceProvider"
+EOF;
+		$container = new Container();
+
+		$loader = new IniLoader($container);
+		$loader->load($content);
+
+		$this->assertEquals('called', $container->get('foo'));
+	}
+
+	/**
+	 * @testdox Loading an invalid string
+	 */
+	public function testLoadInvalidString ()
+	{
+		$content = <<<EOF
+[provider]
+foo unit test
+EOF;
+		$container = new Container();
+
+		$loader = new IniLoader($container);
+		$loader->load($content);
+
+		$this->assertFalse($container->has('foo'));
+	}
+
+	/**
+	 * @testdox Loading an invalid class
+	 */
+	public function testLoadWithInvalidClass ()
+	{
+		$content = <<<EOF
+[provider]
+foo = "\\NotAvailableServiceProvider"
+EOF;
+		$container = new Container();
+
+		$loader = new IniLoader($container);
+		$loader->load($content);
+
+		$this->assertFalse($container->has('foo'));
+	}
+
+	/**
+	 * @testdox Loading a file
+	 */
+	public function testLoadFile ()
+	{
+		$container = new Container();
+
+		$loader = new IniLoader($container);
+		$loader->loadFromFile(dirname(__DIR__) . '/data/services.ini');
+
+		$this->assertEquals('called', $container->get('foo'));
+	}
+}

--- a/tests/unit/DI/Stubs/SimpleServiceProvider.php
+++ b/tests/unit/DI/Stubs/SimpleServiceProvider.php
@@ -1,0 +1,12 @@
+<?php
+use Joomla\DI\ServiceProviderInterface;
+use Joomla\DI\Container;
+
+class SimpleServiceProvider implements ServiceProviderInterface
+{
+
+	public function register (Container $container, $alias = null)
+	{
+		$container->set($alias, 'called');
+	}
+}

--- a/tests/unit/DI/data/services.ini
+++ b/tests/unit/DI/data/services.ini
@@ -1,0 +1,2 @@
+[provider]
+foo = "\\SimpleServiceProvider"


### PR DESCRIPTION
Showcases a simple ini service provider loader. Further loaders can be implemented trough the LoaderInterface.

Idea comes from Symfony http://symfony.com/doc/current/components/dependency_injection/introduction.html#setting-up-the-container-with-configuration-files