### PR TITLE
Removed the faulty event name atttribute

### DIFF
--- a/libraries/incubator/Event/DelegatingDispatcher.php
+++ b/libraries/incubator/Event/DelegatingDispatcher.php
@@ -54,16 +54,15 @@ final class DelegatingDispatcher implements DispatcherInterface
 	/**
 	 * Dispatches an event to all registered listeners.
 	 *
-	 * @param   string          $name   The name of the event to dispatch.
 	 * @param   EventInterface  $event  The event to pass to the event handlers/listeners.
 	 *
 	 * @return  EventInterface  The event after being passed through all listeners.
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function dispatch($name, EventInterface $event = null)
+	public function dispatch(EventInterface $event)
 	{
-		return $this->dispatcher->dispatch($name, $event);
+		return $this->dispatcher->dispatch($event);
 	}
 
 	/**

--- a/libraries/incubator/Event/Dispatcher.php
+++ b/libraries/incubator/Event/Dispatcher.php
@@ -376,20 +376,14 @@ class Dispatcher implements DispatcherInterface
 	/**
 	 * Dispatches an event to all registered listeners.
 	 *
-	 * @param   string          $name   The name of the event to dispatch.
 	 * @param   EventInterface  $event  The event to pass to the event handlers/listeners.
 	 *
 	 * @return  EventInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function dispatch($name, EventInterface $event = null)
+	public function dispatch(EventInterface $event)
 	{
-		if (!($event instanceof EventInterface))
-		{
-			$event = $this->getDefaultEvent($name);
-		}
-
 		if (isset($this->listeners[$event->getName()]))
 		{
 			foreach ($this->listeners[$event->getName()] as $listener)
@@ -423,7 +417,7 @@ class Dispatcher implements DispatcherInterface
 			$event = $this->getDefaultEvent($event);
 		}
 
-		return $this->dispatch($event->getName(), $event);
+		return $this->dispatch($event);
 	}
 
 	/**

--- a/libraries/incubator/Event/DispatcherInterface.php
+++ b/libraries/incubator/Event/DispatcherInterface.php
@@ -31,16 +31,13 @@ interface DispatcherInterface
 	/**
 	 * Dispatches an event to all registered listeners.
 	 *
-	 * @param   string          $name   The name of the event to dispatch.
-	 *                                  The name of the event is the name of the method that is invoked on listeners.
 	 * @param   EventInterface  $event  The event to pass to the event handlers/listeners.
-	 *                                  If not supplied, an empty EventInterface instance is created.
 	 *
 	 * @return  EventInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function dispatch($name, EventInterface $event = null);
+	public function dispatch(EventInterface $event);
 
 	/**
 	 * Removes an event listener from the specified event.

--- a/libraries/incubator/Renderer/EventDecorator.php
+++ b/libraries/incubator/Renderer/EventDecorator.php
@@ -57,15 +57,15 @@ class EventDecorator implements RendererInterface, StreamInterface
 	 */
 	public function registerContentType($type, $handler)
 	{
-		$this->dispatcher->dispatch('onBeforeRegisterContentType', new RegisterContentTypeEvent($type, $handler));
+		$this->dispatcher->dispatch(new RegisterContentTypeEvent($type, $handler));
 
 		try
 		{
 			$this->renderer->registerContentType($type, $handler);
-			$this->dispatcher->dispatch('onAfterRegisterContentType', new RegisterContentTypeSuccessEvent($type, $handler));
+			$this->dispatcher->dispatch(new RegisterContentTypeSuccessEvent($type, $handler));
 		} catch (\Exception $exception)
 		{
-			$this->dispatcher->dispatch('onRegisterContentTypeFailure', new RegisterContentTypeFailureEvent($type, $exception));
+			$this->dispatcher->dispatch(new RegisterContentTypeFailureEvent($type, $exception));
 			throw $exception;
 		}
 	}
@@ -338,17 +338,17 @@ class EventDecorator implements RendererInterface, StreamInterface
 		if (preg_match('~^visit(.+)~', $method, $match))
 		{
 			$type = $match[1];
-			$this->dispatcher->dispatch('onBeforeRender' . $type, new RenderContentTypeEvent($type, $arguments[0]));
+			$this->dispatcher->dispatch(new RenderContentTypeEvent($type, $arguments[0]));
 
 			try
 			{
 				$result = call_user_func_array([$this->renderer, $method], $arguments);
-				$this->dispatcher->dispatch('onAfterRender' . $type, new RenderContentTypeSuccessEvent($type, $this->renderer));
+				$this->dispatcher->dispatch(new RenderContentTypeSuccessEvent($type, $this->renderer));
 
 				return $result;
 			} catch (\Exception $exception)
 			{
-				$this->dispatcher->dispatch('onRender' . $type . 'Failure', new RenderContentTypeFailureEvent($type, $exception));
+				$this->dispatcher->dispatch(new RenderContentTypeFailureEvent($type, $exception));
 				throw $exception;
 			}
 		}

--- a/tests/unit/Renderer/EventDecoratorCest.php
+++ b/tests/unit/Renderer/EventDecoratorCest.php
@@ -101,8 +101,8 @@ class EventDecoratorCest
 
 			/** @var Dispatcher $mockDispatcher */
 			$mockDispatcher = Mockery::mock(Dispatcher::class);
-			$mockDispatcher->shouldReceive('dispatch')->once()->with('onBeforeRender' . $contentType, RenderContentTypeEvent::class);
-			$mockDispatcher->shouldReceive('dispatch')->once()->with('onAfterRender' . $contentType, RenderContentTypeSuccessEvent::class);
+			$mockDispatcher->shouldReceive('dispatch')->once()->with(RenderContentTypeEvent::class);
+			$mockDispatcher->shouldReceive('dispatch')->once()->with(RenderContentTypeSuccessEvent::class);
 
 			/** @var RendererInterface $mockRenderer */
 			$mockRenderer = Mockery::mock(Renderer::class);


### PR DESCRIPTION
The behavior in the dispatch function is inconsistent. This PR removes the name attribute and makes the event parameter required.